### PR TITLE
feat(smtp): add ssl config in MailClient config

### DIFF
--- a/src/main/java/fr/wseduc/webutils/email/SMTPSender.java
+++ b/src/main/java/fr/wseduc/webutils/email/SMTPSender.java
@@ -31,6 +31,10 @@ public class SMTPSender extends NotificationHelper implements EmailSender {
                 .setHostname(config.getString("hostname"))
                 .setPort(config.getInteger("port", 25));
 
+        if (config.containsKey("ssl") && Boolean.TRUE.equals(config.getBoolean("ssl"))) {
+            smtpConfig.setSsl(config.getBoolean("ssl"));
+        }
+
         if (config.containsKey("username") && config.containsKey("password")) {
             smtpConfig.setUsername(config.getString("username"))
                     .setPassword(config.getString("password"));


### PR DESCRIPTION
## Description

Cette Pull Request permet de rajouter une configuration SSL en fonction de la configuration du SMTP
Elle est nécessaire pour éviter les erreurs :
```
SEVERE Failed to send mail from SMTP
io.vertx.core.impl.NoStackTraceThrowable: connection has been closed by the server
SEVERE [MassMail] Error while sending mail (connection has been closed by the server)
```

Car certaines configuration de SMTP peut nécessiter d'activer le SSL

Dans ce cas là, il faudra configurer dans l'emailConfig du module infra : 

```
  "emailConfig": {
      "hostname": "${host}",
      "port": ${port},
      "type": "SMTP",
      ...
      "ssl": true,
      ...
    },
```

