### PR TITLE
feat(mfa): #WB-1608, move SMS sending utilities from entcore

### DIFF
--- a/src/main/java/fr/wseduc/sms/Sms.java
+++ b/src/main/java/fr/wseduc/sms/Sms.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © "Open Digital Education", 2016
+ *
+ * This program is published by "Open Digital Education".
+ * You must indicate the name of the software and the company in any production /contribution
+ * using the software and indicate on the home page of the software industry in question,
+ * "powered by Open Digital Education" with a reference to the website: https://opendigitaleducation.com/.
+ *
+ * This program is free software, licensed under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, version 3 of the License.
+ *
+ * You can redistribute this application and/or modify it since you respect the terms of the GNU Affero General Public License.
+ * If you modify the source code and then use this modified source code in your creation, you must make available the source code of your modifications.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with the software.
+ * If not, please see : <http://www.gnu.org/licenses/>. Full compliance requires reading the terms of this license and following its directives.
+
+ */
+
+package fr.wseduc.sms;
+
+import fr.wseduc.webutils.Server;
+import fr.wseduc.webutils.StringValidation;
+import fr.wseduc.webutils.http.Renders;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.shareddata.LocalMap;
+import org.apache.commons.lang3.StringUtils;
+
+import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
+
+//-------------------
+public class Sms {
+
+	private static final Logger log = LoggerFactory.getLogger(Sms.class);
+//-------------------
+
+	//--------------------------------------
+	private static class SmsFactoryHolder {
+	//--------------------------------------
+		private static final SmsFactory instance = new SmsFactory();
+	}
+
+	//--------------------------------------
+	public static class SmsFactory {
+	//--------------------------------------
+		private Vertx vertx;
+		private EventBus eb;
+		private JsonObject config;
+		private String smsProvider;
+		private String smsAddress;
+
+		protected SmsFactory() {
+		}
+
+		public void init(Vertx vertx, JsonObject config) {
+			this.eb = Server.getEventBus(vertx);
+			this.vertx = vertx;
+			this.config = config;
+			LocalMap<Object, Object> server = vertx.sharedData().getLocalMap("server");
+			if(server != null && server.get("smsProvider") != null) {
+				smsProvider = (String) server.get("smsProvider");
+				final String node = (String) server.get("node");
+				smsAddress = (node != null ? node : "") + "entcore.sms";
+			} else {
+				smsAddress = "entcore.sms";
+			}
+		}
+
+		public Sms newInstance( Renders render ) {
+			return new Sms( (render == null) ? new Renders(vertx, config) : render );
+		}
+
+
+		protected JsonObject getSmsObjectFor(final String target, final String body) {
+			return new JsonObject()
+			.put("provider", smsProvider)
+			.put("action", "send-sms")
+			.put("parameters", new JsonObject()
+				.put("receivers", new fr.wseduc.webutils.collections.JsonArray().add(target))
+				.put("message", body)
+				.put("senderForResponse", true)
+				.put("noStopClause", true));
+		}
+
+		protected Future<SmsSendingReport> send(final JsonObject smsObject) {
+			Promise<SmsSendingReport> promise = Promise.promise();
+			eb.request(smsAddress, smsObject, handlerToAsyncHandler(event -> {
+				if("error".equals(event.body().getString("status"))){
+					promise.fail(event.body().getString("message", ""));
+				} else {
+					try {
+						final SmsSendingReport report = event.body().getJsonObject("data").mapTo(SmsSendingReport.class);
+						promise.complete(report);
+					} catch(Exception e) {
+						log.error("An error occurred while deserializing data from sms sender to class SmsSendingReport. Data to deserialize were " + event.body(), e);
+						promise.fail(e);
+					}
+				}
+			}));
+			return promise.future();
+		}
+	}
+
+	////////////////////////////////////////
+
+	public static SmsFactory getFactory() {
+		return SmsFactoryHolder.instance;
+	}
+
+	////////////////////////////////////////
+
+	private Renders render;
+
+	private Sms(final Renders render) {
+		this.render = render;
+	}
+
+	public Future<SmsSendingReport> send(HttpServerRequest request, final String phone, String template, JsonObject params){
+		return send(request, phone, template, params, null);
+	}
+
+	/**
+	 * @param request Http request that triggered the sms
+	 * @param phone Complete phone number of the user
+	 * @param template Template to use to generate the body of the template
+	 * @param params Parameters to populate the SMS template
+	 * @param module (optional) Name of the module that requested the SMS
+	 * @return A report of the send job
+	 */
+	public Future<SmsSendingReport> send(HttpServerRequest request, final String phone, String template, JsonObject params, final String module){
+		if (StringUtils.isBlank(phone)) {
+			return Future.failedFuture("empty.target");
+		}
+
+		final String formattedPhone = StringValidation.formatPhone(phone);
+
+		return processTemplate(request, template, params)
+		.compose( body -> {
+			final JsonObject smsObject = getFactory().getSmsObjectFor(formattedPhone, body);
+			return getFactory().send( smsObject );
+		});
+	}
+
+	private Future<String> processTemplate(HttpServerRequest request, String template, JsonObject params){
+		Promise<String> promise = Promise.promise();
+		render.processTemplate(request, template, params, body -> {
+			if (body != null) {
+				promise.complete(body);
+			} else {
+				promise.fail("template.error");
+			}
+		});
+		return promise.future();
+	}
+}

--- a/src/main/java/fr/wseduc/sms/SmsSendingReport.java
+++ b/src/main/java/fr/wseduc/sms/SmsSendingReport.java
@@ -1,0 +1,39 @@
+package fr.wseduc.sms;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Execution report of a SMS sending job.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SmsSendingReport {
+    /** Ids of the SMS sent by the provider (can be used for tracking). */
+    private final String[] ids;
+    /** Recipients whose numbers are not valid and to whom the SMS could not be sent.*/
+    private final String[] invalidReceivers;
+    /** Recipients whose numbers are valid and to whom the SMS could be sent.*/
+    private final String[] validReceivers;
+
+    @JsonCreator
+    public SmsSendingReport(@JsonProperty("ids") final String[] ids,
+                           @JsonProperty("invalidReceivers") final String[] invalidReceivers,
+                           @JsonProperty("validReceivers") final String[] validReceivers) {
+        this.ids = ids;
+        this.invalidReceivers = invalidReceivers;
+        this.validReceivers = validReceivers;
+    }
+
+    public String[] getIds() {
+        return ids;
+    }
+
+    public String[] getInvalidReceivers() {
+        return invalidReceivers;
+    }
+
+    public String[] getValidReceivers() {
+        return validReceivers;
+    }
+}

--- a/src/main/java/fr/wseduc/webutils/StringValidation.java
+++ b/src/main/java/fr/wseduc/webutils/StringValidation.java
@@ -1,0 +1,19 @@
+package fr.wseduc.webutils;
+
+public final class StringValidation {
+
+    private StringValidation() {}
+
+    public static String obfuscateMobile(String mobile){
+        return mobile.length() > 4 ?
+                mobile.substring(0, mobile.length() - 4).replaceAll(".", ".") +
+                        mobile.substring(mobile.length() - 4) : mobile.replaceAll(".", ".");
+    }
+
+    public static String formatPhone(String phone){
+        final String formattedPhone = phone.replaceAll("[^0-9\\\\+]", "");
+        return !formattedPhone.startsWith("00") && !formattedPhone.startsWith("+") && formattedPhone.startsWith("0") && formattedPhone.length() == 10 ?
+                formattedPhone.replaceFirst("0", "+33") :
+                formattedPhone;
+    }
+}


### PR DESCRIPTION
# Description

Déplacement de la classe Sms de entcore dans web-utils afin de :
- pouvoir décoréler l'envoi de SMS de l'ENT
- garder mod-sms-sender libre de toute dépendance à l'ENT

Ce faisant, il a ausi fallu déplacer des fonctions utilitaires de entcore.StringValidation  dans webutils.StringValidation.
À terme, il faudra poursuivre cette migration de StringValidation (et des autres classes utilitaires non liées directement à l'ENT) à l'extérieur de entcore.commons.

## Fixes

https://opendigitaleducation.atlassian.net/browse/WB-1608

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)

# Checklist:

- [x] My code does not raise any new warnings in Sonar
- [ ] Security threats have been treated and discussed with the DirTech committee
- [x] I have checked that performance tests were not impacted
- [ ] I have created or modified at least one automatic test covering the impacted functionality
- [x] New and existing unit tests pass locally with my changes