### PR TITLE
[ODE] utility functions to create private and public RSA key

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+# Description
+
+Please include a summary of the changes and the related issue.
+
+## Fixes
+
+(Enter here Jira or Redmine ticket(s) links)
+
+## Type of change
+
+Please check options that are relevant.
+
+- [ ] Chore (PATCH)
+- [ ] Doc (PATCH)
+- [ ] Bug fix (PATCH)
+- [ ] New feature (MINOR)
+
+## Tests
+
+1. Describe here the tests you performed
+2. Step by step
+3. With expected results
+
+# Reminder
+
+- Security flaws
+- Performance impacts
+- Unit tests were replayed
+- Unit tests were added and/or changed
+- I have updated the reminder for the version including my modifications
+
+- [ ] All done ! :smiley:


### PR DESCRIPTION
# Description

Add 2 functions to parse RSA public and private keys from in-memory string.

## Fixes

WB-1800

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)

## Tests

1. Modify configuration of the module archive
```json
{
        "main": "org.entcore.archive.Archive",
        ...
        "force-encryption": true,
        "archive-private-key": "-----BEGIN PRIVATE KEY-----...-----END PRIVATE KEY-----"
        ...
}
```
2. Launch the ENT
3. Sign in
4. Go to My Data app
5. Export data
6. Verify that the generated archive is signed

# Reminder

- Security flaws
- Performance impacts
- Unit tests were replayed
- Unit tests were added and/or changed
- I have updated the reminder for the version including my modifications

- [x] All done ! :smiley: