### PR TITLE
[Edifice] Basic HTTP authentication to call content transformer service

### DIFF
--- a/src/main/java/fr/wseduc/transformer/impl/SimpleContentTransformerClient.java
+++ b/src/main/java/fr/wseduc/transformer/impl/SimpleContentTransformerClient.java
@@ -11,6 +11,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 /**
  * Client to call rich content transformer service
@@ -19,14 +20,16 @@ public class SimpleContentTransformerClient implements IContentTransformerClient
 
     private static final Logger log = LoggerFactory.getLogger(SimpleContentTransformerClient.class);
     private final HttpClient httpClient;
+    private final String authHeader;
 
     /**
-     * Constructor
-     * @param vertx vertx instance
-     * @param config content transformer config
+     * @param httpClient HTTP client
+     * @param authHeader Authorization header to authorize calls to content transformer. May be null if we
+     *                   don't use any form of authentication
      */
-    public SimpleContentTransformerClient(HttpClient httpClient) {
+    public SimpleContentTransformerClient(final HttpClient httpClient, final String authHeader) {
         this.httpClient = httpClient;
+        this.authHeader = authHeader;
     }
 
     /**
@@ -45,6 +48,9 @@ public class SimpleContentTransformerClient implements IContentTransformerClient
         });
         request.exceptionHandler(promise::fail);
         request.putHeader("Content-Type", "application/json");
+        if(isNotEmpty(authHeader)) {
+            request.putHeader("Authorization", authHeader);
+        }
         request.end(JsonObject.mapFrom(contentTransformerRequest).encode());
         return promise.future();
     }

--- a/src/main/java/fr/wseduc/transformer/impl/SimpleContentTransformerFactory.java
+++ b/src/main/java/fr/wseduc/transformer/impl/SimpleContentTransformerFactory.java
@@ -5,6 +5,11 @@ import fr.wseduc.transformer.IContentTransformerFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.ClientOptionsBase;
+import io.vertx.core.net.TCPSSLOptions;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -13,6 +18,7 @@ import java.net.URISyntaxException;
  * Simple implementation of content transformer factory
  */
 public class SimpleContentTransformerFactory implements IContentTransformerFactory {
+    private final Logger logger = LoggerFactory.getLogger(SimpleContentTransformerFactory.class);
     private final Vertx vertx;
 
     private final JsonObject contentTransformerConfig;
@@ -31,8 +37,22 @@ public class SimpleContentTransformerFactory implements IContentTransformerFacto
             throw new IllegalStateException("Failed parsing content transformer service url", e);
         }
         final HttpClientOptions options = new HttpClientOptions()
-                .setDefaultHost(uri.getHost())
-                .setDefaultPort(uri.getPort());
-        return new SimpleContentTransformerClient(vertx.createHttpClient(options));
+            .setDefaultHost(uri.getHost())
+            .setDefaultPort(uri.getPort())
+            .setMaxPoolSize(contentTransformerConfig.getInteger("pool", 16))
+            .setKeepAlive(contentTransformerConfig.getBoolean("keepalive", true))
+            .setConnectTimeout(contentTransformerConfig.getInteger("timeout", ClientOptionsBase.DEFAULT_CONNECT_TIMEOUT))
+            .setIdleTimeout(contentTransformerConfig.getInteger("idle-timeout", TCPSSLOptions.DEFAULT_IDLE_TIMEOUT))
+            .setKeepAliveTimeout(contentTransformerConfig.getInteger("keepalive-timeout", HttpClientOptions.DEFAULT_KEEP_ALIVE_TIMEOUT))
+            .setHttp2KeepAliveTimeout(contentTransformerConfig.getInteger("keepalive-timeout", HttpClientOptions.DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT));
+        final String auth = contentTransformerConfig.getString("auth");
+        final String authHeader;
+        if(isEmpty(auth)) {
+            logger.warn("Created content transformer client without authentication header");
+            authHeader = null;
+        } else {
+            authHeader = "Basic " + auth;
+        }
+        return new SimpleContentTransformerClient(vertx.createHttpClient(options), auth);
     }
 }


### PR DESCRIPTION
# Description

Ajout de la possibilité de spécifier un token d'authentification basique HTTP afin de contacter le service de transformation de contenu riche

# Ticket

WB-2004